### PR TITLE
Fix: leaderboard dark mode color scheme

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -25,5 +25,10 @@
         for (i = 0; i < elements.length; i++) {
             elements[i].classList.toggle('dark-ctn');
         }
+
+        let leaderBoard = document.getElementsByClassName("leaderboard")[0];
+        if (leaderBoard !== null) {
+            leaderBoard.classList.toggle("dark");
+        }
     });
 </script>

--- a/_sass/leaderboard.scss
+++ b/_sass/leaderboard.scss
@@ -15,7 +15,7 @@
     }
     .head-blue {
       background-color: #1d539f;
-      color: white;
+      color:  #FFFFFF;;
     }
     tr:nth-child(2n) {
       background-color: rgb(219, 219, 219);
@@ -31,27 +31,30 @@
 
 .leaderboard.dark {
   
-  a {
-    color: white;
+  table {
+    box-shadow: 0px 1px 4px 0px #000000;
   }
 
-  tr:nth-child(2n + 1) {
-    color: white;
+  td {
+    border-color: #565656;
+  }
+
+  th {
+    border-top: None;
+  }
+
+  a {
+    color: #FFFFFF;
+  }
+
+  tr {
+    color: #FFFFFF;
   }
 
   tr:nth-child(2n) {
-    background-color: grey;
-    color: white;
+    background-color: #808080;
   }
 
-  .head-blue {
-      background-color: #1d539f;
-      color: white;
-  }
-
-  .leaderboardName:hover a{
-    color: #1d539f;
-  }
 }
 
 @media only screen and (max-width: 900px) {

--- a/_sass/leaderboard.scss
+++ b/_sass/leaderboard.scss
@@ -29,6 +29,31 @@
   }
 }
 
+.leaderboard.dark {
+  
+  a {
+    color: white;
+  }
+
+  tr:nth-child(2n + 1) {
+    color: white;
+  }
+
+  tr:nth-child(2n) {
+    background-color: grey;
+    color: white;
+  }
+
+  .head-blue {
+      background-color: #1d539f;
+      color: white;
+  }
+
+  .leaderboardName:hover a{
+    color: #1d539f;
+  }
+}
+
 @media only screen and (max-width: 900px) {
   .leaderboard {
     max-width: 100%;

--- a/_sass/leaderboard.scss
+++ b/_sass/leaderboard.scss
@@ -29,6 +29,10 @@
   }
 }
 
+.table td, .table th {
+    border-top: 0px solid #dee2e6;
+}
+
 .leaderboard.dark {
   
   table {
@@ -37,10 +41,6 @@
 
   td {
     border-color: #565656;
-  }
-
-  th {
-    border-top: None;
   }
 
   a {


### PR DESCRIPTION
This PR sets a higher colour scheme for the leaderboard.
This improves the readability of the leaderboard text.

---before---
![image](https://user-images.githubusercontent.com/12957252/141708775-4af3537e-62df-44d9-bb33-ac3c873fcfe0.png)


---after----
![image](https://user-images.githubusercontent.com/12957252/143607384-00ee52c4-998e-43e3-a0f6-654e004412cd.png)




fixes #32 

## Please, go through these steps before you submit a PR.

- [x] My Pod Leader knows I'm working on this Pull Request
- [x] I've explained what the Pull Request is adding.
- [x] I've explained why this is important.

